### PR TITLE
[CI] Re-enable backward compatibility check

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,4 +14,34 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
+      # We cannot simply run the node-diff action, since it will try
+      # to import our package without installing dependencies. So we
+      # install dependencies ourselves first.
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"  # Same as comfy-org/node-diff
+
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          path: pr_repo  # Same as comfy-org/node-diff
+
+      - uses: actions/checkout@v4
+        name: Checkout ComfyUI
+        with:
+          repository: comfyanonymous/ComfyUI
+          ref: v0.3.57
+          path: comfyui
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          pip install ./pr_repo
+          pip install -r ./comfyui/requirements.txt
+
       - uses: comfy-org/node-diff@main
+        env:
+          PYTHONPATH: ${{ github.workspace }}/comfyui

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,7 +7,6 @@ name: Validate backwards compatibility
 on:
   pull_request:
     branches:
-      - master
       - main
 
 jobs:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,7 +2,6 @@
 # Copyright (c) 2025 The Foundry Visionmongers Ltd
 # SPDX-License-Identifier: Apache-2.0
 
-# TODO(DF): Re-enable once initial PR merged to set a baseline.
 name: Validate backwards compatibility
 
 on:


### PR DESCRIPTION
Revert "[CI] Disable backward compatibility check"

This reverts commit ab9ad28d0476f03a4289dd62486ce402d8cd3c2f.

The check was disabled on the initial commit, since there was no history to diff against, so the check failed.

Add dependencies before executing the 3rd party action, otherwise it fails to import our nodes.